### PR TITLE
Block update task if user has updated recently

### DIFF
--- a/main/views.py
+++ b/main/views.py
@@ -46,7 +46,7 @@ def dashboard(request):
                 logout(request)
                 return redirect("/")
             auth_url = ''
-            allow_update = True
+            allow_update = check_update(fitbit_member)
         else:
             allow_update = False
             fitbit_member = ''


### PR DESCRIPTION
This should fix #12 by re-adding `check_update` into the views before the dashboard is rendered.