### PR TITLE
Write task to import fitbit refresh tokens & fix broken ones

### DIFF
--- a/main/management/commands/check_refresh_tokens.py
+++ b/main/management/commands/check_refresh_tokens.py
@@ -1,0 +1,11 @@
+from django.core.management.base import BaseCommand
+from main.models import FitbitMember
+
+
+class Command(BaseCommand):
+    help = 'Update data for all users'
+
+    def handle(self, *args, **options):
+        for fb in FitbitMember.objects.all():
+            print(fb.user.user.oh_member.oh_id)
+            fb._refresh_tokens()

--- a/main/management/commands/update_broken_token.py
+++ b/main/management/commands/update_broken_token.py
@@ -1,0 +1,32 @@
+from django.core.management.base import BaseCommand
+from main.models import FitbitMember
+from open_humans.models import OpenHumansMember
+from datauploader.tasks import fetch_fitbit_data
+# from fitbit.settings import OPENHUMANS_CLIENT_ID, OPENHUMANS_CLIENT_SECRET
+from django.conf import settings
+
+class Command(BaseCommand):
+    help = 'Refresh Fitbit tokens that were previously broken'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--infile', type=str,
+                            help='CSV with project_member_id & refresh_token')
+        parser.add_argument('--delimiter', type=str,
+                            help='CSV delimiter')
+
+    def handle(self, *args, **options):
+        for line in open(options['infile']):
+            if not line.startswith('proj_member_id'):
+                line = line.strip().split(options['delimiter'])
+                oh_id = line[0]
+                oh_refresh_token = line[1]
+                fitbit_refresh_token = line[2]
+                if len(OpenHumansMember.objects.filter(
+                            oh_id=oh_id)) == 1:
+                    oh_member = OpenHumansMember.get(oh_id=oh_id)
+                    fitbit_member = oh_member.fitbit_member
+                    print(fitbit_member)
+                    fitbit_member.refresh_token = fitbit_refresh_token
+                    fitbit_member.save()
+                    fitbit_member._refresh_tokens()
+                    # fetch_fitbit_data.delay(oh_member.oh_id, oh_member.fitbit_member.access_token)

--- a/main/management/commands/update_broken_token.py
+++ b/main/management/commands/update_broken_token.py
@@ -26,7 +26,9 @@ class Command(BaseCommand):
                     oh_member = OpenHumansMember.get(oh_id=oh_id)
                     fitbit_member = oh_member.fitbit_member
                     print(fitbit_member)
-                    fitbit_member.refresh_token = fitbit_refresh_token
-                    fitbit_member.save()
-                    fitbit_member._refresh_tokens()
+                    successful_refresh = fitbit_member._refresh_tokens()
+                    if not successful_refresh:
+                        fitbit_member.refresh_token = fitbit_refresh_token
+                        fitbit_member.save()
+                        fitbit_member._refresh_tokens()
                     # fetch_fitbit_data.delay(oh_member.oh_id, oh_member.fitbit_member.access_token)

--- a/main/models.py
+++ b/main/models.py
@@ -57,6 +57,8 @@ class FitbitMember(models.Model):
             self.access_token = data['access_token']
             self.refresh_token = data['refresh_token']
             self.token_expires = self.get_expiration(data['expires_in'])
-            self.scope =  data['scope']
+            self.scope = data['scope']
             self.userid = data['user_id']
             self.save()
+            return None
+        return 1

--- a/main/models.py
+++ b/main/models.py
@@ -60,5 +60,5 @@ class FitbitMember(models.Model):
             self.scope = data['scope']
             self.userid = data['user_id']
             self.save()
-            return None
-        return 1
+            return True
+        return False


### PR DESCRIPTION
Ok, the main update in this thing is to write the `update_broken_token.py` management task that will allow us to import the tokens that @madprime has already exported. The workflow would be similar to the one we used for doing the import in the first place: 

1. load the CSV to transfer.sh 
2. download it in a `bash` one-off dyno on heroku 
3. run the management command.